### PR TITLE
Ensure that zfs.target is enabled

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 NAME            := lustre-ldiskfs-zfs
 PACKAGE_VERSION := 2
 DIST_VERSION    := $(PACKAGE_VERSION)
-PACKAGE_RELEASE := 2
+PACKAGE_RELEASE := 1
 
 include ./include/rpm.mk
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 NAME            := lustre-ldiskfs-zfs
 PACKAGE_VERSION := 2
 DIST_VERSION    := $(PACKAGE_VERSION)
-PACKAGE_RELEASE := 1
+PACKAGE_RELEASE := 2
 
 include ./include/rpm.mk
 

--- a/lustre-ldiskfs-zfs.spec
+++ b/lustre-ldiskfs-zfs.spec
@@ -5,7 +5,7 @@ BuildRequires: systemd
 
 Name:      lustre-ldiskfs-zfs
 Version:   2
-Release:   2%{?dist}
+Release:   1%{?dist}
 Summary:   Package to install a Lustre storage server with both ldiskfs and ZFS support
 
 License:   MIT
@@ -43,14 +43,14 @@ systemctl start zfs.target
 
 %preun
 %systemd_preun %{unit_name}
-%systemd_post zfs.target
+%systemd_post zfs-import-scan
+%systemd_post zfs-import-cache
+%systemd_post zfs-mount
 
 %changelog
-* Mon Apr 30 2018 Joe Grund <joe.grund@intel.com> 2-2
-- Fixup spec to enable / disable correct units.
-
 * Fri Mar 2 2018 Joe Grund <joe.grund@intel.com> 2-1
 - Add unit to start ZFS services post install.
+- Fixup spec to enable / disable correct units.
 
 * Tue Aug 22 2017 Brian J. Murrell <brian.murrell@intel.com> 1-3
 - Remove LU-9745 hack now that that is fixed upstream

--- a/lustre-ldiskfs-zfs.spec
+++ b/lustre-ldiskfs-zfs.spec
@@ -5,7 +5,7 @@ BuildRequires: systemd
 
 Name:      lustre-ldiskfs-zfs
 Version:   2
-Release:   1%{?dist}
+Release:   2%{?dist}
 Summary:   Package to install a Lustre storage server with both ldiskfs and ZFS support
 
 License:   MIT
@@ -31,16 +31,24 @@ mkdir -p %{buildroot}%{_unitdir}
 cp %{unit_name} %{buildroot}%{_unitdir}
 
 %post
-systemctl disable zfs-import-scan
-systemctl disable zfs-import-cache
-systemctl disable zfs-mount
-systemctl enable %{unit_name}
+%systemd_preun zfs-import-scan
+%systemd_preun zfs-import-cache
+%systemd_preun zfs-mount
+%systemd_post %{unit_name}
+%systemd_post zfs.target
 systemctl start zfs.target
 
 %files
 %{_unitdir}/%{unit_name}
 
+%preun
+%systemd_preun %{unit_name}
+%systemd_post zfs.target
+
 %changelog
+* Mon Apr 30 2018 Joe Grund <joe.grund@intel.com> 2-2
+- Fixup spec to enable / disable correct units.
+
 * Fri Mar 2 2018 Joe Grund <joe.grund@intel.com> 2-1
 - Add unit to start ZFS services post install.
 


### PR DESCRIPTION
The zfs.target service is not enabled, which means it will not start on
reboot. In addition, the services we disabled were not stopped.

Make sure we enable and stop services, and remove our changes on
uninstall.

Signed-off-by: Joe Grund <joe.grund@intel.com>