### PR TITLE
Fix dkms package name for 2.10.4 and future lustre versions

### DIFF
--- a/lustre-ldiskfs-zfs.spec.in
+++ b/lustre-ldiskfs-zfs.spec.in
@@ -23,7 +23,7 @@ server capable of creating just ldiskfs targets.
 Summary:   Package to install a Lustre storage server with both ldiskfs and ZFS support
 
 Requires:  lustre
-Requires:  lustre-dkms
+Requires:  lustre-zfs-dkms
 Requires:  kmod-lustre-osd-ldiskfs
 Requires:  zfs
 


### PR DESCRIPTION
In 2.10.4 and 2.11.0 lustre dkms got several flavors.
lustre-zfs-dkms is the queivilent of the old lustre-dkms.

Signed-off-by: Nathaniel Clark <nclark@whamcloud.com>