### PR TITLE
Make lustre-zfs-dkms dependency weak

### DIFF
--- a/lustre-ldiskfs-zfs.spec
+++ b/lustre-ldiskfs-zfs.spec
@@ -23,9 +23,13 @@ server capable of creating just ldiskfs targets.
 Summary:   Package to install a Lustre storage server with both ldiskfs and ZFS support
 
 Requires:  lustre
-Requires:  lustre-zfs-dkms
-Requires:  kmod-lustre-osd-ldiskfs
 Requires:  zfs
+# Primary requirements - but lustre-all-dkms satisfyies these, and
+# also conflicts
+Recommends:  lustre-zfs-dkms
+Recommends:  kmod-lustre-osd-ldiskfs
+# Allowable if installed
+Suggests: lustre-all-dkms
 
 %{?systemd_requires}
 

--- a/lustre-ldiskfs-zfs.spec
+++ b/lustre-ldiskfs-zfs.spec
@@ -24,7 +24,7 @@ Summary:   Package to install a Lustre storage server with both ldiskfs and ZFS 
 
 Requires:  lustre
 Requires:  zfs
-# Primary requirements - but lustre-all-dkms satisfyies these, and
+# Primary requirements - but lustre-all-dkms satisfies these, and
 # also conflicts
 Recommends:  lustre-zfs-dkms
 Recommends:  kmod-lustre-osd-ldiskfs


### PR DESCRIPTION
If lustre-all-dkms was installed as solution for upgrade from lustre-dkms,
let it continue to be installed, and don't fail.

Fixes whamcloud/integrated-manager-for-lustre#883

Signed-off-by: Nathaniel Clark <nclark@whamcloud.com>